### PR TITLE
Defined CODEOWNERS to include our usernames - JT

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
-
+# These owners will be the default owners for everything in the repo.
+# @TechNerd-019, @CherryTreeGee811, @SemiDoge, @Dante262, and @AleixBossa will be requested for
+# review when someone opens a pull request.
+*    @TechNerd-019 @CherryTreeGee811 @SemiDoge @Dante262 @AleixBossa


### PR DESCRIPTION
Group 1 members should have full access, as this is Group 1's repository.