### PR TITLE
Catch InvalidOperationExceptions in DAL - JT

### DIFF
--- a/ScientificOperationsCenter/DAL/RadiationMeasurementsRepository.cs
+++ b/ScientificOperationsCenter/DAL/RadiationMeasurementsRepository.cs
@@ -29,6 +29,11 @@ namespace ScientificOperationsCenter.DAL
                 // Todo: Log Exception
                 throw new DataAccessException("An error occurred while accessing the database.", dbEx);
             }
+            catch (InvalidOperationException iEx)
+            {
+                // Todo: Log Exception
+                throw new DataAccessException("An error occurred while accessing the database.", iEx);
+            }
             catch (Exception gEx)
             {
                 // Todo: Log Exception
@@ -49,6 +54,11 @@ namespace ScientificOperationsCenter.DAL
                 // Todo: Log Exception
                 throw new DataAccessException("An error occurred while accessing the database.", dbEx);
             }
+            catch (InvalidOperationException iEx)
+            {
+                // Todo: Log Exception
+                throw new DataAccessException("An error occurred while accessing the database.", iEx);
+            }
             catch (Exception gEx)
             {
                 // Todo: Log Exception
@@ -68,6 +78,11 @@ namespace ScientificOperationsCenter.DAL
             {
                 // Todo: Log Exception
                 throw new DataAccessException("An error occurred while accessing the database.", dbEx);
+            }
+              catch (InvalidOperationException iEx)
+            {
+                // Todo: Log Exception
+                throw new DataAccessException("An error occurred while accessing the database.", iEx);
             }
             catch (Exception gEx)
             {

--- a/ScientificOperationsCenter/DAL/TemperaturesRepository.cs
+++ b/ScientificOperationsCenter/DAL/TemperaturesRepository.cs
@@ -29,6 +29,11 @@ namespace ScientificOperationsCenter.DAL
                 // Todo: Log Exception
                 throw new DataAccessException("An error occurred while accessing the database.", dbEx);
             }
+            catch (InvalidOperationException iEx)
+            {
+                // Todo: Log Exception
+                throw new DataAccessException("An error occurred while accessing the database.", iEx);
+            }
             catch (Exception gEx)
             {
                 // Todo: Log Exception
@@ -49,6 +54,11 @@ namespace ScientificOperationsCenter.DAL
                 // Todo: Log Exception
                 throw new DataAccessException("An error occurred while accessing the database.", dbEx);
             }
+            catch (InvalidOperationException iEx)
+            {
+                // Todo: Log Exception
+                throw new DataAccessException("An error occurred while accessing the database.", iEx);
+            }
             catch (Exception gEx)
             {
                 // Todo: Log Exception
@@ -68,6 +78,11 @@ namespace ScientificOperationsCenter.DAL
             {
                 // Todo: Log Exception
                 throw new DataAccessException("An error occurred while accessing the database.", dbEx);
+            }
+            catch (InvalidOperationException iEx)
+            {
+                // Todo: Log Exception
+                throw new DataAccessException("An error occurred while accessing the database.", iEx);
             }
             catch (Exception gEx)
             {


### PR DESCRIPTION
These can occur when the connection string is invalid or when used database is inaccessible. One example of the latter example is if running application in a docker without a proper bridge setup.