### PR TITLE
Simplify code further

### DIFF
--- a/ScientificOperationsCenter.Api.Tests/Mocks/MockIRadiationMeasurementsMapper.cs
+++ b/ScientificOperationsCenter.Api.Tests/Mocks/MockIRadiationMeasurementsMapper.cs
@@ -15,37 +15,37 @@ namespace ScientificOperationsCenter.Api.Tests.Mocks
 
             var radiationMeasurementsSameDay = new List<RadiationMeasurementsTimeSum>()
             {
-                new() { Time = new TimeOnly(01, 00), TotalMilligrays = 430 },
-                new() { Time = new TimeOnly(6, 00), TotalMilligrays = 400 },
-                new() { Time = new TimeOnly(21, 00), TotalMilligrays = 110 },
-                new() { Time = new TimeOnly(03, 00), TotalMilligrays = 160 },
-                new() { Time = new TimeOnly(04, 00), TotalMilligrays = 190 },
-                new() { Time = new TimeOnly(02, 00), TotalMilligrays = 160 }
+                new() { Time = new (01, 00), TotalMilligrays = 430 },
+                new() { Time = new (6, 00), TotalMilligrays = 400 },
+                new() { Time = new (21, 00), TotalMilligrays = 110 },
+                new() { Time = new (03, 00), TotalMilligrays = 160 },
+                new() { Time = new (04, 00), TotalMilligrays = 190 },
+                new() { Time = new (02, 00), TotalMilligrays = 160 }
             };
 
 
             var radiationMeasurementsSameMonth = new List<RadiationMeasurementsDateSum>()
             {
-                new() { Date = new DateOnly(2024, 10, 09), TotalMilligrays = 120 },
-                new() { Date = new DateOnly(2024, 10, 02), TotalMilligrays = 250 },
-                new() { Date = new DateOnly(2024, 10, 11), TotalMilligrays = 120 },
-                new() { Date = new DateOnly(2024, 10, 20), TotalMilligrays = 130 },
-                new() { Date = new DateOnly(2024, 10, 21), TotalMilligrays = 110 },
-                new() { Date = new DateOnly(2024, 10, 06), TotalMilligrays = 150 },
-                new() { Date = new DateOnly(2024, 10, 01), TotalMilligrays = 120 },
+                new() { Date = new (2024, 10, 09), TotalMilligrays = 120 },
+                new() { Date = new (2024, 10, 02), TotalMilligrays = 250 },
+                new() { Date = new (2024, 10, 11), TotalMilligrays = 120 },
+                new() { Date = new (2024, 10, 20), TotalMilligrays = 130 },
+                new() { Date = new (2024, 10, 21), TotalMilligrays = 110 },
+                new() { Date = new (2024, 10, 06), TotalMilligrays = 150 },
+                new() { Date = new (2024, 10, 01), TotalMilligrays = 120 },
             };
 
 
             var radiationMeasurementsSameYear = new List<RadiationMeasurementsDateSum>()
             {
-                new() { Date = new DateOnly(2025, 08, 01), TotalMilligrays = 140 },
-                new() { Date = new DateOnly(2025, 05, 01), TotalMilligrays = 120 },
-                new() { Date = new DateOnly(2025, 07, 01), TotalMilligrays = 160 },
-                new() { Date = new DateOnly(2025, 11, 01), TotalMilligrays = 110 },
-                new() { Date = new DateOnly(2025, 09, 01), TotalMilligrays = 130 },
-                new() { Date = new DateOnly(2025, 10, 01), TotalMilligrays = 120 },
-                new() { Date = new DateOnly(2025, 06, 01), TotalMilligrays = 110 },
-                new() { Date = new DateOnly(2025, 12, 01), TotalMilligrays = 150 },
+                new() { Date = new (2025, 08, 01), TotalMilligrays = 140 },
+                new() { Date = new (2025, 05, 01), TotalMilligrays = 120 },
+                new() { Date = new (2025, 07, 01), TotalMilligrays = 160 },
+                new() { Date = new (2025, 11, 01), TotalMilligrays = 110 },
+                new() { Date = new (2025, 09, 01), TotalMilligrays = 130 },
+                new() { Date = new (2025, 10, 01), TotalMilligrays = 120 },
+                new() { Date = new (2025, 06, 01), TotalMilligrays = 110 },
+                new() { Date = new (2025, 12, 01), TotalMilligrays = 150 },
             };
 
 

--- a/ScientificOperationsCenter.Api.Tests/Mocks/MockIRadiationMeasurementsRepository.cs
+++ b/ScientificOperationsCenter.Api.Tests/Mocks/MockIRadiationMeasurementsRepository.cs
@@ -14,17 +14,17 @@ namespace ScientificOperationsCenter.Api.Tests.Mocks
 
             var radiationMeasurements = new List<RadiationMeasurements>()
             {
-                new() { Id = 1, Date = new DateOnly(2024, 10, 08), Time = new TimeOnly(16, 00), Milligrays = 100 },
-                new() { Id = 2, Date = new DateOnly(2024, 10, 08), Time = new TimeOnly(19, 00), Milligrays = 120 },
-                new() { Id = 3, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(21, 30), Milligrays = 120 },
-                new() { Id = 4, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(21, 00), Milligrays = 110 },
-                new() { Id = 5, Date = new DateOnly(2025, 01, 05), Time = new TimeOnly(04, 30), Milligrays = 200 },
-                new() { Id = 6, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(06, 00), Milligrays = 160 },
-                new() { Id = 7, Date = new DateOnly(2024, 10, 08), Time = new TimeOnly(12, 00), Milligrays = 190 },
-                new() { Id = 8, Date = new DateOnly(2024, 11, 02), Time = new TimeOnly(09, 10), Milligrays = 100 },
-                new() { Id = 9, Date = new DateOnly(2024, 11, 03), Time = new TimeOnly(04, 30), Milligrays = 200 },
-                new() { Id = 10, Date = new DateOnly(2025, 01, 03), Time = new TimeOnly(04, 30), Milligrays = 200 },
-                new() { Id = 11, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(06, 40), Milligrays = 120 }
+                new() { Id = 1, Date = new (2024, 10, 08), Time = new (16, 00), Milligrays = 100 },
+                new() { Id = 2, Date = new (2024, 10, 08), Time = new (19, 00), Milligrays = 120 },
+                new() { Id = 3, Date = new (2024, 10, 09), Time = new (21, 30), Milligrays = 120 },
+                new() { Id = 4, Date = new (2024, 10, 09), Time = new (21, 00), Milligrays = 110 },
+                new() { Id = 5, Date = new (2025, 01, 05), Time = new (04, 30), Milligrays = 200 },
+                new() { Id = 6, Date = new (2024, 10, 09), Time = new (06, 00), Milligrays = 160 },
+                new() { Id = 7, Date = new (2024, 10, 08), Time = new (12, 00), Milligrays = 190 },
+                new() { Id = 8, Date = new (2024, 11, 02), Time = new (09, 10), Milligrays = 100 },
+                new() { Id = 9, Date = new (2024, 11, 03), Time = new (04, 30), Milligrays = 200 },
+                new() { Id = 10, Date = new (2025, 01, 03), Time = new (04, 30), Milligrays = 200 },
+                new() { Id = 11, Date = new (2024, 10, 09), Time = new (06, 40), Milligrays = 120 }
             };
 
             mock.Setup(m => m.GetByDayAsync(It.IsAny<DateOnly>())).ReturnsAsync((DateOnly date) => 

--- a/ScientificOperationsCenter.Api.Tests/Mocks/MockIRadiationMeasurementsService.cs
+++ b/ScientificOperationsCenter.Api.Tests/Mocks/MockIRadiationMeasurementsService.cs
@@ -15,42 +15,42 @@ namespace ScientificOperationsCenter.Api.Tests.Mocks
 
             var radiationMeasurementsSameDay = new List<RadiationMeasurements>()
             {
-                new() { Id = 1, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(01, 00), Milligrays = 160 },
-                new() { Id = 2, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(01, 20), Milligrays = 150 },
-                new() { Id = 3, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(01, 50), Milligrays = 120 },
-                new() { Id = 4, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(6, 30), Milligrays = 120 },
-                new() { Id = 5, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(21, 02), Milligrays = 110 },
-                new() { Id = 6, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(06, 50), Milligrays = 133 },
-                new() { Id = 7, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(03, 00), Milligrays = 160 },
-                new() { Id = 8, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(06, 20), Milligrays = 150 },
-                new() { Id = 9, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(04, 00), Milligrays = 190 },
-                new() { Id = 10, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(02, 10), Milligrays = 160 },
+                new() { Id = 1, Date = new (2024, 10, 09), Time = new (01, 00), Milligrays = 160 },
+                new() { Id = 2, Date = new (2024, 10, 09), Time = new (01, 20), Milligrays = 150 },
+                new() { Id = 3, Date = new (2024, 10, 09), Time = new (01, 50), Milligrays = 120 },
+                new() { Id = 4, Date = new (2024, 10, 09), Time = new (6, 30), Milligrays = 120 },
+                new() { Id = 5, Date = new (2024, 10, 09), Time = new (21, 02), Milligrays = 110 },
+                new() { Id = 6, Date = new (2024, 10, 09), Time = new (06, 50), Milligrays = 133 },
+                new() { Id = 7, Date = new (2024, 10, 09), Time = new (03, 00), Milligrays = 160 },
+                new() { Id = 8, Date = new (2024, 10, 09), Time = new (06, 20), Milligrays = 150 },
+                new() { Id = 9, Date = new (2024, 10, 09), Time = new (04, 00), Milligrays = 190 },
+                new() { Id = 10, Date = new (2024, 10, 09), Time = new (02, 10), Milligrays = 160 },
             };
 
 
             var radiationMeasurementsSameMonth = new List<RadiationMeasurements>()
             {
-                new() { Id = 1, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(6, 30), Milligrays = 120 },
-                new() { Id = 2, Date = new DateOnly(2024, 10, 02), Time = new TimeOnly(21, 00), Milligrays = 150 },
-                new() { Id = 3, Date = new DateOnly(2024, 10, 11), Time = new TimeOnly(11, 07), Milligrays = 120 },
-                new() { Id = 4, Date = new DateOnly(2024, 10, 20), Time = new TimeOnly(08, 02), Milligrays = 130 },
-                new() { Id = 5, Date = new DateOnly(2024, 10, 21), Time = new TimeOnly(02, 03), Milligrays = 110 },
-                new() { Id = 6, Date = new DateOnly(2024, 10, 06), Time = new TimeOnly(05, 30), Milligrays = 150 },
-                new() { Id = 7, Date = new DateOnly(2024, 10, 02), Time = new TimeOnly(07, 02), Milligrays = 130 },
-                new() { Id = 8, Date = new DateOnly(2024, 10, 01), Time = new TimeOnly(08, 30), Milligrays = 120 },
+                new() { Id = 1, Date = new (2024, 10, 09), Time = new (6, 30), Milligrays = 120 },
+                new() { Id = 2, Date = new (2024, 10, 02), Time = new (21, 00), Milligrays = 150 },
+                new() { Id = 3, Date = new (2024, 10, 11), Time = new (11, 07), Milligrays = 120 },
+                new() { Id = 4, Date = new (2024, 10, 20), Time = new (08, 02), Milligrays = 130 },
+                new() { Id = 5, Date = new (2024, 10, 21), Time = new (02, 03), Milligrays = 110 },
+                new() { Id = 6, Date = new (2024, 10, 06), Time = new (05, 30), Milligrays = 150 },
+                new() { Id = 7, Date = new (2024, 10, 02), Time = new (07, 02), Milligrays = 130 },
+                new() { Id = 8, Date = new (2024, 10, 01), Time = new (08, 30), Milligrays = 120 },
             };
 
 
             var radiationMeasurementsSameYear = new List<RadiationMeasurements>()
             {
-                new() { Id = 1, Date = new DateOnly(2025, 05, 20), Time = new TimeOnly(6, 30), Milligrays = 120 },
-                new() { Id = 2, Date = new DateOnly(2025, 06, 09), Time = new TimeOnly(11, 07), Milligrays = 110 },
-                new() { Id = 3, Date = new DateOnly(2025, 07, 10), Time = new TimeOnly(12, 00), Milligrays = 160 },
-                new() { Id = 4, Date = new DateOnly(2025, 08, 12), Time = new TimeOnly(13, 10), Milligrays = 140 },
-                new() { Id = 5, Date = new DateOnly(2025, 09, 02), Time = new TimeOnly(14, 20), Milligrays = 130 },
-                new() { Id = 6, Date = new DateOnly(2025, 10, 01), Time = new TimeOnly(09, 30), Milligrays = 120 },
-                new() { Id = 7, Date = new DateOnly(2025, 11, 26), Time = new TimeOnly(03, 00), Milligrays = 110 },
-                new() { Id = 8, Date = new DateOnly(2025, 12, 30), Time = new TimeOnly(02, 00), Milligrays = 150 },
+                new() { Id = 1, Date = new (2025, 05, 20), Time = new (6, 30), Milligrays = 120 },
+                new() { Id = 2, Date = new (2025, 06, 09), Time = new (11, 07), Milligrays = 110 },
+                new() { Id = 3, Date = new (2025, 07, 10), Time = new (12, 00), Milligrays = 160 },
+                new() { Id = 4, Date = new (2025, 08, 12), Time = new (13, 10), Milligrays = 140 },
+                new() { Id = 5, Date = new (2025, 09, 02), Time = new (14, 20), Milligrays = 130 },
+                new() { Id = 6, Date = new (2025, 10, 01), Time = new (09, 30), Milligrays = 120 },
+                new() { Id = 7, Date = new (2025, 11, 26), Time = new (03, 00), Milligrays = 110 },
+                new() { Id = 8, Date = new (2025, 12, 30), Time = new (02, 00), Milligrays = 150 },
             };
 
 

--- a/ScientificOperationsCenter.Api.Tests/Mocks/MockITemperaturesMapper.cs
+++ b/ScientificOperationsCenter.Api.Tests/Mocks/MockITemperaturesMapper.cs
@@ -15,37 +15,37 @@ namespace ScientificOperationsCenter.Api.Tests.Mocks
 
             var temperaturesSameDay = new List<TemperaturesTimeAverage>()
             {
-                new() { Time = new TimeOnly(01, 00), AverageTemperature = -4 },
-                new() { Time = new TimeOnly(21, 00), AverageTemperature = 30 },
-                new() { Time = new TimeOnly(06, 00), AverageTemperature = 12 },
-                new() { Time = new TimeOnly(03, 00), AverageTemperature = -2 },
-                new() { Time = new TimeOnly(04, 00), AverageTemperature = 23 },
-                new() { Time = new TimeOnly(02, 00), AverageTemperature = 0 },
+                new() { Time = new (01, 00), AverageTemperature = -4 },
+                new() { Time = new (21, 00), AverageTemperature = 30 },
+                new() { Time = new (06, 00), AverageTemperature = 12 },
+                new() { Time = new (03, 00), AverageTemperature = -2 },
+                new() { Time = new (04, 00), AverageTemperature = 23 },
+                new() { Time = new (02, 00), AverageTemperature = 0 },
             };
 
 
             var temperaturesSameMonth = new List<TemperaturesDateAverage>()
             {
-                new() { Date = new DateOnly(2024, 10, 09), AverageTemperature = -1 },
-                new() { Date = new DateOnly(2024, 10, 02), AverageTemperature = 33 },
-                new() { Date = new DateOnly(2024, 10, 11), AverageTemperature = 12 },
-                new() { Date = new DateOnly(2024, 10, 20), AverageTemperature = 1 },
-                new() { Date = new DateOnly(2024, 10, 21), AverageTemperature = 20 },
-                new() { Date = new DateOnly(2024, 10, 06), AverageTemperature = 4 },
-                new() { Date = new DateOnly(2024, 10, 01), AverageTemperature = 32 },
+                new() { Date = new (2024, 10, 09), AverageTemperature = -1 },
+                new() { Date = new (2024, 10, 02), AverageTemperature = 33 },
+                new() { Date = new (2024, 10, 11), AverageTemperature = 12 },
+                new() { Date = new (2024, 10, 20), AverageTemperature = 1 },
+                new() { Date = new (2024, 10, 21), AverageTemperature = 20 },
+                new() { Date = new (2024, 10, 06), AverageTemperature = 4 },
+                new() { Date = new (2024, 10, 01), AverageTemperature = 32 },
             };
 
 
             var temperaturesSameYear = new List<TemperaturesDateAverage>()
             {
-                new() { Date = new DateOnly(2025, 10, 01), AverageTemperature = 20 },
-                new() { Date = new DateOnly(2025, 06, 01), AverageTemperature = 0 },
-                new() { Date = new DateOnly(2025, 07, 01), AverageTemperature = 6 },
-                new() { Date = new DateOnly(2025, 12, 01), AverageTemperature = 20 },
-                new() { Date = new DateOnly(2025, 08, 01), AverageTemperature = 15 },
-                new() { Date = new DateOnly(2025, 09, 01), AverageTemperature = 19 },
-                new() { Date = new DateOnly(2025, 11, 01), AverageTemperature = 12 },
-                new() { Date = new DateOnly(2025, 05, 01), AverageTemperature = -2 },
+                new() { Date = new (2025, 10, 01), AverageTemperature = 20 },
+                new() { Date = new (2025, 06, 01), AverageTemperature = 0 },
+                new() { Date = new (2025, 07, 01), AverageTemperature = 6 },
+                new() { Date = new (2025, 12, 01), AverageTemperature = 20 },
+                new() { Date = new (2025, 08, 01), AverageTemperature = 15 },
+                new() { Date = new (2025, 09, 01), AverageTemperature = 19 },
+                new() { Date = new (2025, 11, 01), AverageTemperature = 12 },
+                new() { Date = new (2025, 05, 01), AverageTemperature = -2 },
             };
 
 

--- a/ScientificOperationsCenter.Api.Tests/Mocks/MockITemperaturesRepository.cs
+++ b/ScientificOperationsCenter.Api.Tests/Mocks/MockITemperaturesRepository.cs
@@ -14,18 +14,18 @@ namespace ScientificOperationsCenter.Api.Tests.Mocks
 
             var temperatures = new List<Temperatures>()
             {
-                new() { Id = 1, Date = new DateOnly(2024, 10, 08), Time = new TimeOnly(16, 00), TemperatureCelcius = -4 },
-                new() { Id = 2, Date = new DateOnly(2024, 10, 08), Time = new TimeOnly(19, 00), TemperatureCelcius = 12 },
-                new() { Id = 3, Date = new DateOnly(2024, 10, 08), Time = new TimeOnly(19, 20), TemperatureCelcius = 22 },
-                new() { Id = 4, Date = new DateOnly(2024, 10, 08), Time = new TimeOnly(12, 00), TemperatureCelcius = 8 },
-                new() { Id = 5, Date = new DateOnly(2024, 11, 03), Time = new TimeOnly(04, 30), TemperatureCelcius = 5 },
-                new() { Id = 6, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(21, 30), TemperatureCelcius = 12 },
-                new() { Id = 7, Date = new DateOnly(2024, 10, 08), Time = new TimeOnly(12, 40), TemperatureCelcius = 10 },
-                new() { Id = 8, Date = new DateOnly(2025, 01, 03), Time = new TimeOnly(05, 30), TemperatureCelcius = 15 },
-                new() { Id = 9, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(21, 00), TemperatureCelcius = 10 },
-                new() { Id = 10, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(21, 31), TemperatureCelcius = 9 },
-                new() { Id = 11, Date = new DateOnly(2024, 11, 02), Time = new TimeOnly(09, 10), TemperatureCelcius = -2 },
-                new() { Id = 12, Date = new DateOnly(2025, 01, 05), Time = new TimeOnly(03, 30), TemperatureCelcius = 5 }
+                new() { Id = 1, Date = new (2024, 10, 08), Time = new (16, 00), TemperatureCelcius = -4 },
+                new() { Id = 2, Date = new (2024, 10, 08), Time = new (19, 00), TemperatureCelcius = 12 },
+                new() { Id = 3, Date = new (2024, 10, 08), Time = new (19, 20), TemperatureCelcius = 22 },
+                new() { Id = 4, Date = new (2024, 10, 08), Time = new (12, 00), TemperatureCelcius = 8 },
+                new() { Id = 5, Date = new (2024, 11, 03), Time = new (04, 30), TemperatureCelcius = 5 },
+                new() { Id = 6, Date = new (2024, 10, 09), Time = new (21, 30), TemperatureCelcius = 12 },
+                new() { Id = 7, Date = new (2024, 10, 08), Time = new (12, 40), TemperatureCelcius = 10 },
+                new() { Id = 8, Date = new (2025, 01, 03), Time = new (05, 30), TemperatureCelcius = 15 },
+                new() { Id = 9, Date = new (2024, 10, 09), Time = new (21, 00), TemperatureCelcius = 10 },
+                new() { Id = 10, Date = new (2024, 10, 09), Time = new (21, 31), TemperatureCelcius = 9 },
+                new() { Id = 11, Date = new (2024, 11, 02), Time = new (09, 10), TemperatureCelcius = -2 },
+                new() { Id = 12, Date = new (2025, 01, 05), Time = new (03, 30), TemperatureCelcius = 5 }
             };
 
 

--- a/ScientificOperationsCenter.Api.Tests/Mocks/MockITemperaturesService.cs
+++ b/ScientificOperationsCenter.Api.Tests/Mocks/MockITemperaturesService.cs
@@ -15,47 +15,47 @@ namespace ScientificOperationsCenter.Api.Tests.Mocks
 
             var temperaturesSameDay = new List<Temperatures>()
             {
-                new() { Id = 1, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(01, 00), TemperatureCelcius = -4 },
-                new() { Id = 2, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(01, 20), TemperatureCelcius = -9 },
-                new() { Id = 3, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(01, 50), TemperatureCelcius = 10 },
-                new() { Id = 4, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(6, 30), TemperatureCelcius = 20 },
-                new() { Id = 5, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(21, 02), TemperatureCelcius = 30 },
-                new() { Id = 6, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(06, 50), TemperatureCelcius = 12 },
-                new() { Id = 7, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(03, 00), TemperatureCelcius = -2 },
-                new() { Id = 8, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(06, 20), TemperatureCelcius = 21 },
-                new() { Id = 9, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(04, 00), TemperatureCelcius = 23 },
-                new() { Id = 10, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(02, 10), TemperatureCelcius = 0 },
+                new() { Id = 1, Date = new (2024, 10, 09), Time = new (01, 00), TemperatureCelcius = -4 },
+                new() { Id = 2, Date = new (2024, 10, 09), Time = new (01, 20), TemperatureCelcius = -9 },
+                new() { Id = 3, Date = new (2024, 10, 09), Time = new (01, 50), TemperatureCelcius = 10 },
+                new() { Id = 4, Date = new (2024, 10, 09), Time = new (6, 30), TemperatureCelcius = 20 },
+                new() { Id = 5, Date = new (2024, 10, 09), Time = new (21, 02), TemperatureCelcius = 30 },
+                new() { Id = 6, Date = new (2024, 10, 09), Time = new (06, 50), TemperatureCelcius = 12 },
+                new() { Id = 7, Date = new (2024, 10, 09), Time = new (03, 00), TemperatureCelcius = -2 },
+                new() { Id = 8, Date = new (2024, 10, 09), Time = new (06, 20), TemperatureCelcius = 21 },
+                new() { Id = 9, Date = new (2024, 10, 09), Time = new (04, 00), TemperatureCelcius = 23 },
+                new() { Id = 10, Date = new (2024, 10, 09), Time = new (02, 10), TemperatureCelcius = 0 },
             };
 
 
             var temperaturesSameMonth = new List<Temperatures>()
             {
-                new() { Id = 1, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(6, 30), TemperatureCelcius = -1 },
-                new() { Id = 2, Date = new DateOnly(2024, 10, 02), Time = new TimeOnly(21, 00), TemperatureCelcius = 33 },
-                new() { Id = 3, Date = new DateOnly(2024, 10, 11), Time = new TimeOnly(11, 07), TemperatureCelcius = 12 },
-                new() { Id = 4, Date = new DateOnly(2024, 10, 20), Time = new TimeOnly(08, 02), TemperatureCelcius = 1 },
-                new() { Id = 5, Date = new DateOnly(2024, 10, 21), Time = new TimeOnly(02, 03), TemperatureCelcius = 20 },
-                new() { Id = 6, Date = new DateOnly(2024, 10, 21), Time = new TimeOnly(02, 30), TemperatureCelcius = 10 },
-                new() { Id = 7, Date = new DateOnly(2024, 10, 06), Time = new TimeOnly(05, 30), TemperatureCelcius = 4 },
-                new() { Id = 8, Date = new DateOnly(2024, 10, 02), Time = new TimeOnly(07, 02), TemperatureCelcius = 5 },
-                new() { Id = 9, Date = new DateOnly(2024, 10, 01), Time = new TimeOnly(08, 30), TemperatureCelcius = 32 },
-                new() { Id = 10, Date = new DateOnly(2024, 10, 01), Time = new TimeOnly(08, 30), TemperatureCelcius = 22 },
-                new() { Id = 11, Date = new DateOnly(2024, 10, 01), Time = new TimeOnly(08, 30), TemperatureCelcius = 28 }
+                new() { Id = 1, Date = new (2024, 10, 09), Time = new (6, 30), TemperatureCelcius = -1 },
+                new() { Id = 2, Date = new (2024, 10, 02), Time = new (21, 00), TemperatureCelcius = 33 },
+                new() { Id = 3, Date = new (2024, 10, 11), Time = new (11, 07), TemperatureCelcius = 12 },
+                new() { Id = 4, Date = new (2024, 10, 20), Time = new (08, 02), TemperatureCelcius = 1 },
+                new() { Id = 5, Date = new (2024, 10, 21), Time = new (02, 03), TemperatureCelcius = 20 },
+                new() { Id = 6, Date = new (2024, 10, 21), Time = new (02, 30), TemperatureCelcius = 10 },
+                new() { Id = 7, Date = new (2024, 10, 06), Time = new (05, 30), TemperatureCelcius = 4 },
+                new() { Id = 8, Date = new (2024, 10, 02), Time = new (07, 02), TemperatureCelcius = 5 },
+                new() { Id = 9, Date = new (2024, 10, 01), Time = new (08, 30), TemperatureCelcius = 32 },
+                new() { Id = 10, Date = new (2024, 10, 01), Time = new (08, 30), TemperatureCelcius = 22 },
+                new() { Id = 11, Date = new (2024, 10, 01), Time = new (08, 30), TemperatureCelcius = 28 }
             };
 
 
             var temperaturesSameYear = new List<Temperatures>()
             {
-                new() { Id = 1, Date = new DateOnly(2025, 05, 21), Time = new TimeOnly(6, 30), TemperatureCelcius = -2 },
-                new() { Id = 2, Date = new DateOnly(2025, 05, 20), Time = new TimeOnly(6, 30), TemperatureCelcius = -4 },
-                new() { Id = 3, Date = new DateOnly(2025, 06, 09), Time = new TimeOnly(11, 07), TemperatureCelcius = 0 },
-                new() { Id = 4, Date = new DateOnly(2025, 07, 10), Time = new TimeOnly(12, 00), TemperatureCelcius = 6 },
-                new() { Id = 5, Date = new DateOnly(2025, 08, 12), Time = new TimeOnly(13, 10), TemperatureCelcius = 15 },
-                new() { Id = 6, Date = new DateOnly(2025, 09, 02), Time = new TimeOnly(14, 20), TemperatureCelcius = 19 },
-                new() { Id = 7, Date = new DateOnly(2025, 10, 01), Time = new TimeOnly(09, 30), TemperatureCelcius = 20 },
-                new() { Id = 8, Date = new DateOnly(2025, 11, 26), Time = new TimeOnly(03, 00), TemperatureCelcius = 12 },
-                new() { Id = 9, Date = new DateOnly(2025, 12, 29), Time = new TimeOnly(02, 00), TemperatureCelcius = 20 },
-                new() { Id = 10, Date = new DateOnly(2025, 12, 30), Time = new TimeOnly(02, 00), TemperatureCelcius = 34 }
+                new() { Id = 1, Date = new (2025, 05, 21), Time = new (6, 30), TemperatureCelcius = -2 },
+                new() { Id = 2, Date = new (2025, 05, 20), Time = new (6, 30), TemperatureCelcius = -4 },
+                new() { Id = 3, Date = new (2025, 06, 09), Time = new (11, 07), TemperatureCelcius = 0 },
+                new() { Id = 4, Date = new (2025, 07, 10), Time = new (12, 00), TemperatureCelcius = 6 },
+                new() { Id = 5, Date = new (2025, 08, 12), Time = new (13, 10), TemperatureCelcius = 15 },
+                new() { Id = 6, Date = new (2025, 09, 02), Time = new (14, 20), TemperatureCelcius = 19 },
+                new() { Id = 7, Date = new (2025, 10, 01), Time = new (09, 30), TemperatureCelcius = 20 },
+                new() { Id = 8, Date = new (2025, 11, 26), Time = new (03, 00), TemperatureCelcius = 12 },
+                new() { Id = 9, Date = new (2025, 12, 29), Time = new (02, 00), TemperatureCelcius = 20 },
+                new() { Id = 10, Date = new (2025, 12, 30), Time = new (02, 00), TemperatureCelcius = 34 }
             };
 
 

--- a/ScientificOperationsCenter.Api.Tests/Mocks/MockScientificOperationsCenterContext.cs
+++ b/ScientificOperationsCenter.Api.Tests/Mocks/MockScientificOperationsCenterContext.cs
@@ -17,43 +17,43 @@ namespace ScientificOperationsCenter.Api.Tests.Mocks
 
             mock.Temperatures.AddRange(new List<Temperatures>
             {
-                new() { Id = 1, Date = new DateOnly(2024, 09, 02), Time = new TimeOnly(16, 00), TemperatureCelcius = 20 },
-                new() { Id = 2, Date = new DateOnly(2024, 09, 05), Time = new TimeOnly(15, 00), TemperatureCelcius = 15 },
-                new() { Id = 3, Date = new DateOnly(2024, 09, 07), Time = new TimeOnly(12, 00), TemperatureCelcius = -10 },
-                new() { Id = 4, Date = new DateOnly(2024, 10, 08), Time = new TimeOnly(16, 00), TemperatureCelcius = -4 },
-                new() { Id = 5, Date = new DateOnly(2024, 10, 08), Time = new TimeOnly(19, 00), TemperatureCelcius = 12 },
-                new() { Id = 6, Date = new DateOnly(2024, 10, 08), Time = new TimeOnly(12, 00), TemperatureCelcius = 11 },
-                new() { Id = 7, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(21, 30), TemperatureCelcius = 12 },
-                new() { Id = 8, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(21, 00), TemperatureCelcius = 10 },
-                new() { Id = 9, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(06, 00), TemperatureCelcius = 9 },
-                new() { Id = 10, Date = new DateOnly(2024, 11, 02), Time = new TimeOnly(09, 10), TemperatureCelcius = -2 },
-                new() { Id = 11, Date = new DateOnly(2024, 11, 03), Time = new TimeOnly(04, 30), TemperatureCelcius = 5 },
-                new() { Id = 12, Date = new DateOnly(2024, 12, 21), Time = new TimeOnly(04, 50), TemperatureCelcius = 8 },
-                new() { Id = 13, Date = new DateOnly(2024, 12, 10), Time = new TimeOnly(04, 10), TemperatureCelcius = 1 },
-                new() { Id = 14, Date = new DateOnly(2024, 12, 08), Time = new TimeOnly(04, 30), TemperatureCelcius = 5 },
-                new() { Id = 15, Date = new DateOnly(2025, 01, 03), Time = new TimeOnly(05, 30), TemperatureCelcius = 15 },
-                new() { Id = 16, Date = new DateOnly(2025, 01, 05), Time = new TimeOnly(03, 30), TemperatureCelcius = 5 }
+                new() { Id = 1, Date = new (2024, 09, 02), Time = new (16, 00), TemperatureCelcius = 20 },
+                new() { Id = 2, Date = new (2024, 09, 05), Time = new (15, 00), TemperatureCelcius = 15 },
+                new() { Id = 3, Date = new (2024, 09, 07), Time = new (12, 00), TemperatureCelcius = -10 },
+                new() { Id = 4, Date = new (2024, 10, 08), Time = new (16, 00), TemperatureCelcius = -4 },
+                new() { Id = 5, Date = new (2024, 10, 08), Time = new (19, 00), TemperatureCelcius = 12 },
+                new() { Id = 6, Date = new (2024, 10, 08), Time = new (12, 00), TemperatureCelcius = 11 },
+                new() { Id = 7, Date = new (2024, 10, 09), Time = new (21, 30), TemperatureCelcius = 12 },
+                new() { Id = 8, Date = new (2024, 10, 09), Time = new (21, 00), TemperatureCelcius = 10 },
+                new() { Id = 9, Date = new (2024, 10, 09), Time = new (06, 00), TemperatureCelcius = 9 },
+                new() { Id = 10, Date = new (2024, 11, 02), Time = new (09, 10), TemperatureCelcius = -2 },
+                new() { Id = 11, Date = new (2024, 11, 03), Time = new (04, 30), TemperatureCelcius = 5 },
+                new() { Id = 12, Date = new (2024, 12, 21), Time = new (04, 50), TemperatureCelcius = 8 },
+                new() { Id = 13, Date = new (2024, 12, 10), Time = new (04, 10), TemperatureCelcius = 1 },
+                new() { Id = 14, Date = new (2024, 12, 08), Time = new (04, 30), TemperatureCelcius = 5 },
+                new() { Id = 15, Date = new (2025, 01, 03), Time = new (05, 30), TemperatureCelcius = 15 },
+                new() { Id = 16, Date = new (2025, 01, 05), Time = new (03, 30), TemperatureCelcius = 5 }
             });
 
 
             mock.RadiationMeasurements.AddRange(new List<RadiationMeasurements>
             {
-                new() { Id = 1, Date = new DateOnly(2024, 09, 08), Time = new TimeOnly(16, 00), Milligrays = 100 },
-                new() { Id = 2, Date = new DateOnly(2024, 09, 08), Time = new TimeOnly(15, 00), Milligrays = 140 },
-                new() { Id = 3, Date = new DateOnly(2024, 09, 08), Time = new TimeOnly(12, 00), Milligrays = 162 },
-                new() { Id = 4, Date = new DateOnly(2024, 10, 08), Time = new TimeOnly(16, 00), Milligrays = 100 },
-                new() { Id = 5, Date = new DateOnly(2024, 10, 08), Time = new TimeOnly(19, 00), Milligrays = 120 },
-                new() { Id = 6, Date = new DateOnly(2024, 10, 08), Time = new TimeOnly(12, 00), Milligrays = 190 },
-                new() { Id = 7, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(21, 30), Milligrays = 120 },
-                new() { Id = 8, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(21, 00), Milligrays = 110 },
-                new() { Id = 9, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(06, 00), Milligrays = 160 },
-                new() { Id = 10, Date = new DateOnly(2024, 11, 02), Time = new TimeOnly(09, 10), Milligrays = 100 },
-                new() { Id = 11, Date = new DateOnly(2024, 11, 03), Time = new TimeOnly(02, 30), Milligrays = 200 },
-                new() { Id = 12, Date = new DateOnly(2024, 12, 01), Time = new TimeOnly(04, 20), Milligrays = 120 },
-                new() { Id = 13, Date = new DateOnly(2024, 12, 02), Time = new TimeOnly(04, 10), Milligrays = 132 },
-                new() { Id = 14, Date = new DateOnly(2024, 12, 05), Time = new TimeOnly(07, 30), Milligrays = 126 },
-                new() { Id = 15, Date = new DateOnly(2025, 01, 03), Time = new TimeOnly(04, 30), Milligrays = 200 },
-                new() { Id = 16, Date = new DateOnly(2025, 01, 05), Time = new TimeOnly(04, 30), Milligrays = 200 }
+                new() { Id = 1, Date = new (2024, 09, 08), Time = new (16, 00), Milligrays = 100 },
+                new() { Id = 2, Date = new (2024, 09, 08), Time = new (15, 00), Milligrays = 140 },
+                new() { Id = 3, Date = new (2024, 09, 08), Time = new (12, 00), Milligrays = 162 },
+                new() { Id = 4, Date = new (2024, 10, 08), Time = new (16, 00), Milligrays = 100 },
+                new() { Id = 5, Date = new (2024, 10, 08), Time = new (19, 00), Milligrays = 120 },
+                new() { Id = 6, Date = new (2024, 10, 08), Time = new (12, 00), Milligrays = 190 },
+                new() { Id = 7, Date = new (2024, 10, 09), Time = new (21, 30), Milligrays = 120 },
+                new() { Id = 8, Date = new (2024, 10, 09), Time = new (21, 00), Milligrays = 110 },
+                new() { Id = 9, Date = new (2024, 10, 09), Time = new (06, 00), Milligrays = 160 },
+                new() { Id = 10, Date = new (2024, 11, 02), Time = new (09, 10), Milligrays = 100 },
+                new() { Id = 11, Date = new (2024, 11, 03), Time = new (02, 30), Milligrays = 200 },
+                new() { Id = 12, Date = new (2024, 12, 01), Time = new (04, 20), Milligrays = 120 },
+                new() { Id = 13, Date = new (2024, 12, 02), Time = new (04, 10), Milligrays = 132 },
+                new() { Id = 14, Date = new (2024, 12, 05), Time = new (07, 30), Milligrays = 126 },
+                new() { Id = 15, Date = new (2025, 01, 03), Time = new (04, 30), Milligrays = 200 },
+                new() { Id = 16, Date = new (2025, 01, 05), Time = new (04, 30), Milligrays = 200 }
             });
 
             mock.SaveChanges();

--- a/ScientificOperationsCenter.Api/DAL/ScientificOperationsCenterContext.cs
+++ b/ScientificOperationsCenter.Api/DAL/ScientificOperationsCenterContext.cs
@@ -34,41 +34,41 @@ namespace ScientificOperationsCenter.Api.DAL
             base.OnModelCreating(modelBuilder);
 
             modelBuilder.Entity<Temperatures>().HasData(
-               new() { Id = 1, Date = new DateOnly(2024, 09, 02), Time = new TimeOnly(16, 00), TemperatureCelcius = 20 },
-               new() { Id = 2, Date = new DateOnly(2024, 09, 05), Time = new TimeOnly(15, 00), TemperatureCelcius = 15 },
-               new() { Id = 3, Date = new DateOnly(2024, 09, 07), Time = new TimeOnly(12, 00), TemperatureCelcius = -10 },
-               new() { Id = 4, Date = new DateOnly(2024, 10, 08), Time = new TimeOnly(16, 00), TemperatureCelcius = -4 },
-               new() { Id = 5, Date = new DateOnly(2024, 10, 08), Time = new TimeOnly(19, 00), TemperatureCelcius = 12 },
-               new() { Id = 6, Date = new DateOnly(2024, 10, 08), Time = new TimeOnly(12, 00), TemperatureCelcius = 11 },
-               new() { Id = 7, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(21, 30), TemperatureCelcius = 12 },
-               new() { Id = 8, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(21, 00), TemperatureCelcius = 10 },
-               new() { Id = 9, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(06, 00), TemperatureCelcius = 9 },
-               new() { Id = 10, Date = new DateOnly(2024, 11, 02), Time = new TimeOnly(09, 10), TemperatureCelcius = -2 },
-               new() { Id = 11, Date = new DateOnly(2024, 11, 03), Time = new TimeOnly(04, 30), TemperatureCelcius = 5 },
-               new() { Id = 12, Date = new DateOnly(2024, 12, 21), Time = new TimeOnly(04, 50), TemperatureCelcius = 8 },
-               new() { Id = 13, Date = new DateOnly(2024, 12, 10), Time = new TimeOnly(04, 10), TemperatureCelcius = 1 },
-               new() { Id = 14, Date = new DateOnly(2024, 12, 08), Time = new TimeOnly(04, 30), TemperatureCelcius = 5 },
-               new() { Id = 15, Date = new DateOnly(2025, 01, 03), Time = new TimeOnly(05, 30), TemperatureCelcius = 15 },
-               new() { Id = 16, Date = new DateOnly(2025, 01, 05), Time = new TimeOnly(03, 30), TemperatureCelcius = 5 }
+               new() { Id = 1, Date = new (2024, 09, 02), Time = new (16, 00), TemperatureCelcius = 20 },
+               new() { Id = 2, Date = new (2024, 09, 05), Time = new (15, 00), TemperatureCelcius = 15 },
+               new() { Id = 3, Date = new (2024, 09, 07), Time = new (12, 00), TemperatureCelcius = -10 },
+               new() { Id = 4, Date = new (2024, 10, 08), Time = new (16, 00), TemperatureCelcius = -4 },
+               new() { Id = 5, Date = new (2024, 10, 08), Time = new (19, 00), TemperatureCelcius = 12 },
+               new() { Id = 6, Date = new (2024, 10, 08), Time = new (12, 00), TemperatureCelcius = 11 },
+               new() { Id = 7, Date = new (2024, 10, 09), Time = new (21, 30), TemperatureCelcius = 12 },
+               new() { Id = 8, Date = new (2024, 10, 09), Time = new (21, 00), TemperatureCelcius = 10 },
+               new() { Id = 9, Date = new (2024, 10, 09), Time = new (06, 00), TemperatureCelcius = 9 },
+               new() { Id = 10, Date = new (2024, 11, 02), Time = new (09, 10), TemperatureCelcius = -2 },
+               new() { Id = 11, Date = new (2024, 11, 03), Time = new (04, 30), TemperatureCelcius = 5 },
+               new() { Id = 12, Date = new (2024, 12, 21), Time = new (04, 50), TemperatureCelcius = 8 },
+               new() { Id = 13, Date = new (2024, 12, 10), Time = new (04, 10), TemperatureCelcius = 1 },
+               new() { Id = 14, Date = new (2024, 12, 08), Time = new (04, 30), TemperatureCelcius = 5 },
+               new() { Id = 15, Date = new (2025, 01, 03), Time = new (05, 30), TemperatureCelcius = 15 },
+               new() { Id = 16, Date = new (2025, 01, 05), Time = new (03, 30), TemperatureCelcius = 5 }
             );
 
             modelBuilder.Entity<RadiationMeasurements>().HasData(
-               new() { Id = 1, Date = new DateOnly(2024, 09, 08), Time = new TimeOnly(16, 00), Milligrays = 100 },
-               new() { Id = 2, Date = new DateOnly(2024, 09, 08), Time = new TimeOnly(15, 00), Milligrays = 140 },
-               new() { Id = 3, Date = new DateOnly(2024, 09, 08), Time = new TimeOnly(12, 00), Milligrays = 162 },
-               new() { Id = 4, Date = new DateOnly(2024, 10, 08), Time = new TimeOnly(16, 00), Milligrays = 100 },
-               new() { Id = 5, Date = new DateOnly(2024, 10, 08), Time = new TimeOnly(19, 00), Milligrays = 120 },
-               new() { Id = 6, Date = new DateOnly(2024, 10, 08), Time = new TimeOnly(12, 00), Milligrays = 190 },
-               new() { Id = 7, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(21, 30), Milligrays = 120 },
-               new() { Id = 8, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(21, 00), Milligrays = 110 },
-               new() { Id = 9, Date = new DateOnly(2024, 10, 09), Time = new TimeOnly(06, 00), Milligrays = 160 },
-               new() { Id = 10, Date = new DateOnly(2024, 11, 02), Time = new TimeOnly(09, 10), Milligrays = 100 },
-               new() { Id = 11, Date = new DateOnly(2024, 11, 03), Time = new TimeOnly(02, 30), Milligrays = 200 },
-               new() { Id = 12, Date = new DateOnly(2024, 12, 01), Time = new TimeOnly(04, 20), Milligrays = 120 },
-               new() { Id = 13, Date = new DateOnly(2024, 12, 02), Time = new TimeOnly(04, 10), Milligrays = 132 },
-               new() { Id = 14, Date = new DateOnly(2024, 12, 05), Time = new TimeOnly(07, 30), Milligrays = 126 },
-               new() { Id = 15, Date = new DateOnly(2025, 01, 03), Time = new TimeOnly(04, 30), Milligrays = 200 },
-               new() { Id = 16, Date = new DateOnly(2025, 01, 05), Time = new TimeOnly(04, 30), Milligrays = 200 }
+               new() { Id = 1, Date = new (2024, 09, 08), Time = new (16, 00), Milligrays = 100 },
+               new() { Id = 2, Date = new (2024, 09, 08), Time = new (15, 00), Milligrays = 140 },
+               new() { Id = 3, Date = new (2024, 09, 08), Time = new (12, 00), Milligrays = 162 },
+               new() { Id = 4, Date = new (2024, 10, 08), Time = new (16, 00), Milligrays = 100 },
+               new() { Id = 5, Date = new (2024, 10, 08), Time = new (19, 00), Milligrays = 120 },
+               new() { Id = 6, Date = new (2024, 10, 08), Time = new (12, 00), Milligrays = 190 },
+               new() { Id = 7, Date = new (2024, 10, 09), Time = new (21, 30), Milligrays = 120 },
+               new() { Id = 8, Date = new (2024, 10, 09), Time = new (21, 00), Milligrays = 110 },
+               new() { Id = 9, Date = new (2024, 10, 09), Time = new (06, 00), Milligrays = 160 },
+               new() { Id = 10, Date = new (2024, 11, 02), Time = new (09, 10), Milligrays = 100 },
+               new() { Id = 11, Date = new (2024, 11, 03), Time = new (02, 30), Milligrays = 200 },
+               new() { Id = 12, Date = new (2024, 12, 01), Time = new (04, 20), Milligrays = 120 },
+               new() { Id = 13, Date = new (2024, 12, 02), Time = new (04, 10), Milligrays = 132 },
+               new() { Id = 14, Date = new (2024, 12, 05), Time = new (07, 30), Milligrays = 126 },
+               new() { Id = 15, Date = new (2025, 01, 03), Time = new (04, 30), Milligrays = 200 },
+               new() { Id = 16, Date = new (2025, 01, 05), Time = new (04, 30), Milligrays = 200 }
            );
         }
     }


### PR DESCRIPTION
Remove unnecessary type declaration for DateOnly and TimeOnly. Types are already declared for each of the fields in the models.